### PR TITLE
feature(issue-82): Add Slack Service 

### DIFF
--- a/apps/backend/commons/build.gradle
+++ b/apps/backend/commons/build.gradle
@@ -19,6 +19,7 @@ dependencyManagement {
 
 dependencies {
     compileOnly(libs.lombok)
+    api(libs.bundles.slack)
     api(libs.bundles.caffeine.cache)
     api(libs.bundles.json)
     api(libs.bundles.shedlock)

--- a/apps/backend/commons/src/main/java/io/flowinquiry/config/FlowInquiryProperties.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/config/FlowInquiryProperties.java
@@ -2,6 +2,7 @@ package io.flowinquiry.config;
 
 import io.flowinquiry.modules.shared.service.dto.EditionType;
 import jakarta.validation.constraints.NotNull;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -16,6 +17,8 @@ public class FlowInquiryProperties {
     @Setter @NotNull private String version;
 
     @Setter @NotNull private EditionType edition;
+
+    private final Slack slack = new Slack();
 
     private final Http http = new Http();
 
@@ -50,5 +53,12 @@ public class FlowInquiryProperties {
                 private long tokenValidityInSecondsForRememberMe;
             }
         }
+    }
+
+    @Getter
+    @Setter
+    public static class Slack {
+        private String token = "";
+        private Map<String, String> teamChannelMap;
     }
 }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/collab/domain/SlackMessage.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/collab/domain/SlackMessage.java
@@ -1,0 +1,12 @@
+package io.flowinquiry.modules.collab.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SlackMessage {
+
+    private String message;
+    private String team;
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/collab/service/SlackService.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/collab/service/SlackService.java
@@ -1,0 +1,64 @@
+package io.flowinquiry.modules.collab.service;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import io.flowinquiry.config.FlowInquiryProperties;
+import io.flowinquiry.modules.collab.domain.SlackMessage;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class SlackService {
+
+    private final FlowInquiryProperties flowInquiryProperties;
+
+    private final Slack slack = Slack.getInstance();
+
+    public SlackService(FlowInquiryProperties flowInquiryProperties) {
+        this.flowInquiryProperties = flowInquiryProperties;
+    }
+
+    public void sendSlackMessage(SlackMessage slackMessage) {
+        String slackToken = flowInquiryProperties.getSlack().getToken();
+        String message = slackMessage.getMessage();
+        String team = slackMessage.getTeam();
+        String channel = flowInquiryProperties.getSlack().getTeamChannelMap().get(team);
+
+        if (channel == null) {
+            log.error(
+                    "Unable to send a Slack message to team {}, as team channel is missing in configurations.",
+                    team);
+            return;
+        }
+
+        // Build a request object
+        ChatPostMessageRequest request =
+                ChatPostMessageRequest.builder()
+                        .channel(channel) // Use a channel ID `C1234567` is preferable
+                        .text(message)
+                        .build();
+
+        try {
+            ChatPostMessageResponse messageResponse =
+                    slack.methods(slackToken).chatPostMessage(request);
+            if (messageResponse.isOk()) {
+                log.info(
+                        "Slack message successfully sent. message: {} channel: {}",
+                        message,
+                        channel);
+            } else {
+                log.error(
+                        "Sending Slack message {} to channel {} failed due to {}",
+                        message,
+                        channel,
+                        messageResponse.getError());
+            }
+        } catch (IOException | SlackApiException e) {
+            log.error("Error sending Slack message {} to channel {}", message, channel, e);
+        }
+    }
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/event/TicketViolateSlaEvent.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/event/TicketViolateSlaEvent.java
@@ -1,0 +1,16 @@
+package io.flowinquiry.modules.teams.service.event;
+
+import io.flowinquiry.modules.teams.domain.WorkflowTransitionHistory;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class TicketViolateSlaEvent extends ApplicationEvent {
+
+    private final WorkflowTransitionHistory violatingTicket;
+
+    public TicketViolateSlaEvent(Object source, WorkflowTransitionHistory violatingTicket) {
+        super(source);
+        this.violatingTicket = violatingTicket;
+    }
+}

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/job/SendNotificationForTicketsViolateSlaJob.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/job/SendNotificationForTicketsViolateSlaJob.java
@@ -1,35 +1,13 @@
 package io.flowinquiry.modules.teams.service.job;
 
-import static io.flowinquiry.modules.teams.utils.DeduplicationKeyBuilder.buildSlaWarningKey;
-import static j2html.TagCreator.a;
-import static j2html.TagCreator.p;
-import static j2html.TagCreator.strong;
-import static j2html.TagCreator.text;
-
-import io.flowinquiry.modules.collab.EmailContext;
-import io.flowinquiry.modules.collab.domain.Notification;
-import io.flowinquiry.modules.collab.domain.NotificationType;
-import io.flowinquiry.modules.collab.service.MailService;
-import io.flowinquiry.modules.shared.service.cache.DeduplicationCacheService;
-import io.flowinquiry.modules.teams.domain.Ticket;
 import io.flowinquiry.modules.teams.domain.WorkflowTransitionHistory;
-import io.flowinquiry.modules.teams.service.TeamService;
 import io.flowinquiry.modules.teams.service.WorkflowTransitionHistoryService;
-import io.flowinquiry.modules.usermanagement.domain.User;
-import io.flowinquiry.modules.usermanagement.service.mapper.UserMapper;
-import io.flowinquiry.utils.Obfuscator;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.HashSet;
+import io.flowinquiry.modules.teams.service.event.TicketViolateSlaEvent;
 import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Profile;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,33 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class SendNotificationForTicketsViolateSlaJob {
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z");
-
-    private final SimpMessagingTemplate messageTemplate;
-
-    private final TeamService teamService;
-
     private final WorkflowTransitionHistoryService workflowTransitionHistoryService;
 
-    private final MailService mailService;
-
-    private final DeduplicationCacheService deduplicationCacheService;
-
-    private final UserMapper userMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     public SendNotificationForTicketsViolateSlaJob(
-            SimpMessagingTemplate messageTemplate,
-            TeamService teamService,
             WorkflowTransitionHistoryService workflowTransitionHistoryService,
-            MailService mailService,
-            DeduplicationCacheService deduplicationCacheService,
-            UserMapper userMapper) {
-        this.messageTemplate = messageTemplate;
-        this.teamService = teamService;
+            ApplicationEventPublisher eventPublisher) {
         this.workflowTransitionHistoryService = workflowTransitionHistoryService;
-        this.mailService = mailService;
-        this.deduplicationCacheService = deduplicationCacheService;
-        this.userMapper = userMapper;
+        this.eventPublisher = eventPublisher;
     }
 
     @Scheduled(cron = "0 0/1 * * * ?")
@@ -76,94 +36,7 @@ public class SendNotificationForTicketsViolateSlaJob {
                 workflowTransitionHistoryService.getViolatedTransitions();
 
         for (WorkflowTransitionHistory violatingTicket : violatingTickets) {
-            Ticket ticket = violatingTicket.getTicket();
-            Instant slaDueDate = violatingTicket.getSlaDueDate();
-            String formattedSlaDueDate = slaDueDate.atZone(ZoneId.of("UTC")).format(formatter);
-
-            // ✅ Escalate status
-            workflowTransitionHistoryService.escalateTransition(violatingTicket.getId());
-
-            // ✅ Fetch assign user (if exists)
-            User assignUser = ticket.getAssignUser();
-
-            // ✅ Fetch all team managers
-            List<User> teamManagers = teamService.getTeamManagers(ticket.getTeam().getId());
-
-            // ✅ Collect all recipients (Assign User + Team Managers)
-            Set<User> recipients = new HashSet<>();
-            if (assignUser != null) {
-                recipients.add(assignUser);
-            }
-            recipients.addAll(teamManagers); // Always notify managers
-
-            for (User recipient : recipients) {
-                // ✅ Build unique cache key per user to prevent duplicate notifications
-                String cacheKey =
-                        buildSlaWarningKey(
-                                recipient.getId(),
-                                ticket.getId(),
-                                violatingTicket.getTicket().getWorkflow().getId(),
-                                violatingTicket.getEventName(),
-                                violatingTicket.getToState().getId(),
-                                "SendNotificationForTicketsViolateSlaJob");
-
-                if (deduplicationCacheService.containsKey(cacheKey)) {
-                    continue;
-                }
-
-                // ✅ Create notification content
-                String html =
-                        p(
-                                        text("The ticket "),
-                                        a(ticket.getRequestTitle())
-                                                .withHref(
-                                                        "/portal/teams/"
-                                                                + Obfuscator.obfuscate(
-                                                                        ticket.getTeam().getId())
-                                                                + "/tickets/"
-                                                                + Obfuscator.obfuscate(
-                                                                        ticket.getId())),
-                                        text(
-                                                " assigned to you or your team has violated its SLA. The SLA was due on "),
-                                        strong(text(formattedSlaDueDate)),
-                                        text(". Please take necessary action immediately."))
-                                .render();
-
-                // ✅ Create notification object
-                Notification notification =
-                        Notification.builder()
-                                .content(html)
-                                .type(NotificationType.SLA_BREACH)
-                                .user(User.builder().id(recipient.getId()).build())
-                                .isRead(false)
-                                .build();
-
-                // ✅ Send WebSocket notification
-                messageTemplate.convertAndSendToUser(
-                        String.valueOf(recipient.getId()), "/queue/notifications", notification);
-
-                EmailContext emailContext =
-                        new EmailContext(Locale.forLanguageTag("en"))
-                                .setToUser(userMapper.toDto(recipient))
-                                .setSubject(
-                                        "email.ticket.sla.violation.subject",
-                                        ticket.getRequestTitle(),
-                                        ticket.getTeam().getName())
-                                .addVariable("requestTitle", ticket.getRequestTitle())
-                                .addVariable(
-                                        "obfuscatedTeamId",
-                                        Obfuscator.obfuscate(ticket.getTeam().getId()))
-                                .addVariable(
-                                        "obfuscatedTicketId", Obfuscator.obfuscate(ticket.getId()))
-                                .addVariable("slaDueDate", formattedSlaDueDate)
-                                .setTemplate("mail/violatedSlaTicketEmail");
-
-                mailService.sendEmail(emailContext);
-
-                // ✅ Store Key in Deduplication Cache
-                deduplicationCacheService.put(cacheKey, Duration.ofHours(24));
-            }
-
+            eventPublisher.publishEvent(new TicketViolateSlaEvent(this, violatingTicket));
             log.debug("SLA violation notification sent for ticket {}", violatingTicket);
         }
     }

--- a/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/TicketViolatesSlaListener.java
+++ b/apps/backend/commons/src/main/java/io/flowinquiry/modules/teams/service/listener/TicketViolatesSlaListener.java
@@ -1,0 +1,176 @@
+package io.flowinquiry.modules.teams.service.listener;
+
+import static io.flowinquiry.modules.teams.utils.DeduplicationKeyBuilder.buildSlaWarningKey;
+import static j2html.TagCreator.*;
+import static j2html.TagCreator.text;
+
+import io.flowinquiry.modules.collab.EmailContext;
+import io.flowinquiry.modules.collab.domain.Notification;
+import io.flowinquiry.modules.collab.domain.NotificationType;
+import io.flowinquiry.modules.collab.domain.SlackMessage;
+import io.flowinquiry.modules.collab.service.MailService;
+import io.flowinquiry.modules.collab.service.SlackService;
+import io.flowinquiry.modules.shared.service.cache.DeduplicationCacheService;
+import io.flowinquiry.modules.teams.domain.Ticket;
+import io.flowinquiry.modules.teams.domain.WorkflowTransitionHistory;
+import io.flowinquiry.modules.teams.service.TeamService;
+import io.flowinquiry.modules.teams.service.WorkflowTransitionHistoryService;
+import io.flowinquiry.modules.teams.service.event.TicketViolateSlaEvent;
+import io.flowinquiry.modules.usermanagement.domain.User;
+import io.flowinquiry.modules.usermanagement.service.mapper.UserMapper;
+import io.flowinquiry.utils.Obfuscator;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TicketViolatesSlaListener {
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z");
+
+    private final SimpMessagingTemplate messageTemplate;
+
+    private final WorkflowTransitionHistoryService workflowTransitionHistoryService;
+
+    private final TeamService teamService;
+
+    private final MailService mailService;
+
+    private final SlackService slackService;
+
+    private final DeduplicationCacheService deduplicationCacheService;
+
+    private final UserMapper userMapper;
+
+    public TicketViolatesSlaListener(
+            SimpMessagingTemplate messageTemplate,
+            TeamService teamService,
+            WorkflowTransitionHistoryService workflowTransitionHistoryService,
+            MailService mailService,
+            SlackService slackService,
+            DeduplicationCacheService deduplicationCacheService,
+            UserMapper userMapper) {
+
+        this.messageTemplate = messageTemplate;
+        this.teamService = teamService;
+        this.workflowTransitionHistoryService = workflowTransitionHistoryService;
+        this.mailService = mailService;
+        this.slackService = slackService;
+        this.deduplicationCacheService = deduplicationCacheService;
+        this.userMapper = userMapper;
+    }
+
+    @Async("asyncTaskExecutor")
+    @Transactional
+    @EventListener
+    public void onTicketViolatesSla(TicketViolateSlaEvent event) {
+
+        WorkflowTransitionHistory violatingTicket = event.getViolatingTicket();
+        Ticket ticket = violatingTicket.getTicket();
+        Instant slaDueDate = violatingTicket.getSlaDueDate();
+        String formattedSlaDueDate = slaDueDate.atZone(ZoneId.of("UTC")).format(formatter);
+
+        // ✅ Escalate status
+        workflowTransitionHistoryService.escalateTransition(violatingTicket.getId());
+
+        // ✅ Fetch assign user (if exists)
+        User assignUser = ticket.getAssignUser();
+
+        // ✅ Fetch all team managers
+        List<User> teamManagers = teamService.getTeamManagers(ticket.getTeam().getId());
+
+        // ✅ Collect all recipients (Assign User + Team Managers)
+        Set<User> recipients = new HashSet<>();
+        if (assignUser != null) {
+            recipients.add(assignUser);
+        }
+        recipients.addAll(teamManagers); // Always notify managers
+
+        for (User recipient : recipients) {
+            // ✅ Build unique cache key per user to prevent duplicate notifications
+            String cacheKey =
+                    buildSlaWarningKey(
+                            recipient.getId(),
+                            ticket.getId(),
+                            violatingTicket.getTicket().getWorkflow().getId(),
+                            violatingTicket.getEventName(),
+                            violatingTicket.getToState().getId(),
+                            "SendNotificationForTicketsViolateSlaJob");
+
+            if (deduplicationCacheService.containsKey(cacheKey)) {
+                continue;
+            }
+
+            // ✅ Create notification content
+            String html =
+                    p(
+                                    text("The ticket "),
+                                    a(ticket.getRequestTitle())
+                                            .withHref(
+                                                    "/portal/teams/"
+                                                            + Obfuscator.obfuscate(
+                                                                    ticket.getTeam().getId())
+                                                            + "/tickets/"
+                                                            + Obfuscator.obfuscate(ticket.getId())),
+                                    text(
+                                            " assigned to you or your team has violated its SLA. The SLA was due on "),
+                                    strong(text(formattedSlaDueDate)),
+                                    text(". Please take necessary action immediately."))
+                            .render();
+
+            // ✅ Create notification object
+            Notification notification =
+                    Notification.builder()
+                            .content(html)
+                            .type(NotificationType.SLA_BREACH)
+                            .user(User.builder().id(recipient.getId()).build())
+                            .isRead(false)
+                            .build();
+
+            // ✅ Send WebSocket notification
+            messageTemplate.convertAndSendToUser(
+                    String.valueOf(recipient.getId()), "/queue/notifications", notification);
+
+            EmailContext emailContext =
+                    new EmailContext(Locale.forLanguageTag("en"))
+                            .setToUser(userMapper.toDto(recipient))
+                            .setSubject(
+                                    "email.ticket.sla.violation.subject",
+                                    ticket.getRequestTitle(),
+                                    ticket.getTeam().getName())
+                            .addVariable("requestTitle", ticket.getRequestTitle())
+                            .addVariable(
+                                    "obfuscatedTeamId",
+                                    Obfuscator.obfuscate(ticket.getTeam().getId()))
+                            .addVariable("obfuscatedTicketId", Obfuscator.obfuscate(ticket.getId()))
+                            .addVariable("slaDueDate", formattedSlaDueDate)
+                            .setTemplate("mail/violatedSlaTicketEmail");
+
+            mailService.sendEmail(emailContext);
+
+            // ✅ Send Slack message
+            String message =
+                    "The ticket "
+                            + ticket.getId()
+                            + " assigned to you or your team has violated its SLA. "
+                            + "The SLA was due on "
+                            + formattedSlaDueDate;
+            String ticketName = ticket.getTeam().getName();
+            SlackMessage slackMessage = new SlackMessage(message, ticketName);
+            slackService.sendSlackMessage(slackMessage);
+
+            // ✅ Store Key in Deduplication Cache
+            deduplicationCacheService.put(cacheKey, Duration.ofHours(24));
+        }
+    }
+}

--- a/apps/backend/server/src/main/resources/config/application-dev.yml
+++ b/apps/backend/server/src/main/resources/config/application-dev.yml
@@ -50,6 +50,11 @@ server:
 
 
 flowinquiry:
+  slack:
+    token: <Should be set externally>
+    team-channel-map:
+      team=chanOne # Should be changed with team name and channel ID from slack
+      teamTwo=chanTwo # Should be changed with team name and channel ID from slack
   # CORS is only enabled by default with the "dev" profile
   cors:
     allowed-origins: 'http://localhost:3000,http://localhost:8080'

--- a/apps/backend/server/src/main/resources/config/application-prod.yml
+++ b/apps/backend/server/src/main/resources/config/application-prod.yml
@@ -81,6 +81,11 @@ flowinquiry:
   mail:
     from: <Should be set externally>
     base-url: <Should be set externally>
+  slack:
+    token: <Should be set externally>
+    team-channel-map:
+      team=chanOne # Should be changed with team name and channel ID from slack
+      teamTwo=chanTwo # Should be changed with team name and channel ID from slack
   security:
     authentication:
       jwt:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,8 +19,10 @@ shedlockVersion="6.6.0"
 jibVersion="3.4.4"
 caffeineVersion="3.2.0"
 redisHibernateVersion="3.45.0"
+slackClientVersion="1.45.3"
 
 [libraries]
+slack = {module="com.slack.api:slack-api-client", version.ref="slackClientVersion"}
 caffeine = {module="com.github.ben-manes.caffeine:caffeine", version.ref="caffeineVersion"}
 caffeine-jcache = {module="com.github.ben-manes.caffeine:jcache", version.ref="caffeineVersion"}
 redis-hibernate = {module="org.redisson:redisson-hibernate-6", version.ref="redisHibernateVersion"}
@@ -61,3 +63,4 @@ json = ["json-api", "parsson"]
 shedlock = ["shedlock", "shedlock-jdbc-provider"]
 spring-ai = ["spring-ai-openai", "spring-ai-ollama"]
 caffeine-cache = ["caffeine", "caffeine-jcache"]
+slack = ["slack"]


### PR DESCRIPTION
Create Slack Service and create TicketSlaViolation Event and Listener

## Description
This PR closes this [issue 82](https://github.com/flowinquiry/flowinquiry/issues/82)

## Changes Made
Creates Slack Service
Create TicketViolatesSla Event
Moves Logic from the TicketViolatesSla Job to TicketViolatesSla Event Listener
Send slack message to team channels in the TicketViolatesSla Event Listener
Add Flowinquiry Slack configuration (To be set by the teams using Flowinquiry)

(This is a work in progress)
Open questions:
Are there any other events that require slack messages to be sent in their listeners?